### PR TITLE
Added the ability to import geomag in an executable.

### DIFF
--- a/geomag/geomag/geomag.py
+++ b/geomag/geomag/geomag.py
@@ -18,6 +18,12 @@
 import math, os, unittest
 from datetime import date
 
+# Allow finding the default WMM.COF by the frozen executable path
+import sys
+if hasattr(sys, "frozen"):
+    __file__ = os.path.relpath(sys.executable)
+
+
 class GeoMag:
 
     def GeoMag(self, dlat, dlon, h=0, time=date.today()): # latitude (decimal degrees), longitude (decimal degrees), altitude (feet), date


### PR DESCRIPTION
Frozen executables (using cx_Freeze) do not have a **file** attribute. If you are running an executable point the **file** attribute to the executable path.
